### PR TITLE
Plugin shell background image

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "trc-react",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "trc-react",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/src/PluginShell.tsx
+++ b/src/PluginShell.tsx
@@ -15,6 +15,8 @@ interface IProps {
 
 const Header = styled.header`
   background: #eee;
+  background-image: url("https://trcanvasdata.blob.core.windows.net/publicimages/trc-plugin-banner-bgnd.jpg");
+  background-size: cover;
   padding: 3rem 2rem;
   text-align: center;
 `;


### PR DESCRIPTION
Closes #5 

This PR adds a background image to the header in `PluginShell`.

Screenshot:
<img width="1002" alt="Screen Shot 2020-06-08 at 19 08 14" src="https://user-images.githubusercontent.com/31952489/84060233-2650d980-a9bc-11ea-90e4-fa0264d66088.png">
