### PR TITLE
Convert _trcGlobal to context

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "trc-react",
-  "version": "2.0.1",
+  "version": "2.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "trc-react",
-  "version": "2.0.1",
+  "version": "2.1.0",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/src/ColumnCheck.tsx
+++ b/src/ColumnCheck.tsx
@@ -1,30 +1,28 @@
 
 import * as React from "react";
-import * as ReactDOM from "react-dom";
 import * as trcSheet from 'trc-sheet/sheet'
-import { IMajorState } from "./SheetContainer";
-declare var _trcGlobal : IMajorState;
 
-// Helper 
-// Renders Child if columnName is missing 
+import TRCContext from "./context/TRCContext";
+
+// Helper
+// Renders Child if columnName is missing
 // Renders 'OnFound' function if present
 export class ColumnCheck extends React.Component<{
-    columnName : string,    
+    columnName : string,
     OnFound? : (ci : trcSheet.IColumnInfo) => any
 },{}>
 {
-    public constructor(props: any) {
-        super(props);
-    }
+    static contextType = TRCContext;
+
     public render() {
-        if (!_trcGlobal._info) {
-            return null; // not ready yet 
+        if (!this.context._info) {
+            return null; // not ready yet
         }
-        var ci2 = _trcGlobal._info.Columns.find( (ci) => ci.Name == this.props.columnName);
+        var ci2 = this.context._info.Columns.find((ci: any) => ci.Name == this.props.columnName);
         if (!ci2) {
             return this.props.children;
         }
-        
+
         if (!this.props.OnFound) { return null; }
         var child = this.props.OnFound(ci2);
         return child;

--- a/src/ColumnSelector.tsx
+++ b/src/ColumnSelector.tsx
@@ -1,23 +1,24 @@
 import * as React from "react";
 import * as ReactDOM from "react-dom";
 import * as trcSheet from 'trc-sheet/sheet'
-import { IMajorState } from "./SheetContainer";
 
-declare var _trcGlobal : IMajorState;
+import TRCContext from "./context/TRCContext";
 
 
-// Select a column name from the sheet. 
+// Select a column name from the sheet.
 export interface IColumnSelectorProps {
     // Optional predicate to restrict which columns are included
     Include? : (ci : trcSheet.IColumnInfo) => boolean;  // if missing, defaults to IncludeAll
-    Value? : string | trcSheet.IColumnInfo; // Initial value 
+    Value? : string | trcSheet.IColumnInfo; // Initial value
 
     OnChange : (ci : trcSheet.IColumnInfo) => void; // Called when a selection is made
 }
 export class ColumnSelector extends React.Component<IColumnSelectorProps, {}> {
+    static contextType = TRCContext;
+
     constructor(props : any) {
         super(props);
-        this.state = { };    
+        this.state = { };
         this.handleChange = this.handleChange.bind(this);
       }
 
@@ -29,12 +30,12 @@ export class ColumnSelector extends React.Component<IColumnSelectorProps, {}> {
       }
 
     private getValues() : string[] {
-        var cs = _trcGlobal._info.Columns;
-        return cs.map(c => this.include(c) ? c.Name : null);
+        var cs = this.context._info.Columns;
+        return cs.map((c: any) => this.include(c) ? c.Name : null);
     }
 
-    
-    // Used for selecting the "props.Value" item. 
+
+    // Used for selecting the "props.Value" item.
     // value is an index into columnInfo array
     private getValue() : number {
         if (!this.props.Value) {
@@ -43,15 +44,15 @@ export class ColumnSelector extends React.Component<IColumnSelectorProps, {}> {
 
         // props may be the name or the columnInfo. Convert to name
         var x : any= this.props.Value;
-        var name : string = (x.Name) ? x.Name : x;        
+        var name : string = (x.Name) ? x.Name : x;
 
         var cs = this.getValues();
         for(var i  =0; i < cs.length; i++) {
             var c = cs[i];
-            if (c) { // skip nulls 
+            if (c) { // skip nulls
                 if (c == name) {
                     return i;
-                } 
+                }
             }
         }
 
@@ -62,21 +63,21 @@ export class ColumnSelector extends React.Component<IColumnSelectorProps, {}> {
         var idx = event.target.value;
         //alert("set: " + idx);
         // this.setState({value: event.target.value});
-        var ci = _trcGlobal._info.Columns[idx];
-        
+        var ci = this.context._info.Columns[idx];
+
         this.props.OnChange(ci);
       }
 
-      
+
     // Hints on <select>: https://reactjs.org/docs/forms.html#the-select-tag
-    render() {     
-        // <option> must have a 'key' property for React.    
+    render() {
+        // <option> must have a 'key' property for React.
          return <select onChange={this.handleChange} value={this.getValue()}>
-             {this.getValues().map((name,idx) =>              
-             name ? 
+             {this.getValues().map((name,idx) =>
+             name ?
              <option key={idx} value={idx}>{name}</option>
              : null
              )}
-         </select>   
+         </select>
     }
 }

--- a/src/CsvMatchInput.tsx
+++ b/src/CsvMatchInput.tsx
@@ -1,37 +1,36 @@
 import * as React from "react";
 
-import * as trcSheet from 'trc-sheet/sheet'
-
 import { SheetContents, ISheetContents } from "trc-sheet/sheetContents";
-import { IMajorState } from "./SheetContainer";
+
+import TRCContext from "./context/TRCContext";
 
 import { CsvInput } from "./CsvInput";
 import { PluginLink } from "./PluginLink";
 
-declare var _trcGlobal: IMajorState;
-
-// take in a CSV, and match it to the current sheet. 
+// take in a CSV, and match it to the current sheet.
 export class CsvMatchInput extends React.Component<{
-    // If supplied, do this action when we submit. 
-    // If missing, default action is to post 
+    // If supplied, do this action when we submit.
+    // If missing, default action is to post
     onSubmit?: (data: ISheetContents) => Promise<void>
 }, {
-    // Stage 0: inputing raw text 
+    // Stage 0: inputing raw text
     rawText: string;
 
-    // Stage 1: after parsing & validation 
+    // Stage 1: after parsing & validation
     data: ISheetContents;
-    _recIdMatch?: number; // # of recIds that match. 
+    _recIdMatch?: number; // # of recIds that match.
     _recIdTotal?: number; // total # of recIds in the data
 
-    // Stage 2: after submit to posting 
-    posting?: boolean; // after submit, before confirmation 
+    // Stage 2: after submit to posting
+    posting?: boolean; // after submit, before confirmation
 
-    // Stage 3: after successfully posted. Done. 
+    // Stage 3: after successfully posted. Done.
     posted?: string; // after confirmation
-    postedVerNumber?: string; // after confirmation    
+    postedVerNumber?: string; // after confirmation
 }>
 {
+    static contextType = TRCContext;
+
     constructor(props: any) {
         super(props);
         this.state = {
@@ -44,7 +43,7 @@ export class CsvMatchInput extends React.Component<{
     }
 
     private onSubmit(data: ISheetContents) {
-        // Post ot sheet contents. 
+        // Post ot sheet contents.
         this.setState({
             posting: true
         });
@@ -59,7 +58,7 @@ export class CsvMatchInput extends React.Component<{
             })
         }
         else {
-            _trcGlobal.SheetClient.postUpdateAsync(data).then((x) => {
+            this.context.SheetClient.postUpdateAsync(data).then((x: any) => {
                 var msg = "Successfully posted to server. UpdateNumber starts at " + x.VersionTag;
                 this.setState({
                     postedVerNumber: x.VersionTag,
@@ -69,20 +68,20 @@ export class CsvMatchInput extends React.Component<{
         }
     }
     private onValidate(data: ISheetContents) {
-        var cis = _trcGlobal._info.Columns;
+        var cis = this.context._info.Columns;
 
-        // All rows in the sheet must match a column in 
+        // All rows in the sheet must match a column in
         for (var colName in data) {
-            var x = cis.find(ci => ci.Name == colName);
+            var x = cis.find((ci: any) => ci.Name == colName);
             if (!x) {
                 throw "Column '" + colName + "' is not part of this sheet.";
             }
 
-            // $$$ Normalize casing to Possible Values? 
-            // All values in the column should match a possible value. 
+            // $$$ Normalize casing to Possible Values?
+            // All values in the column should match a possible value.
             if (x.PossibleValues && x.PossibleValues.length > 0) {
                 var possible: any = {};
-                x.PossibleValues.forEach(val => possible[val] = true);
+                x.PossibleValues.forEach((val: any) => possible[val] = true);
                 possible[""] = true;
                 possible["---"] = true; // sentinel value for delete.
 
@@ -105,9 +104,9 @@ export class CsvMatchInput extends React.Component<{
         var total = recIds.length
         var match: number = -1;
 
-        // Get RecId match. (Only if contents are available)        
-        if (_trcGlobal._contents) {
-            var index = SheetContents.getSheetContentsIndex(_trcGlobal._contents);
+        // Get RecId match. (Only if contents are available)
+        if (this.context._contents) {
+            var index = SheetContents.getSheetContentsIndex(this.context._contents);
 
             match = 0;
 

--- a/src/ListColumns.tsx
+++ b/src/ListColumns.tsx
@@ -1,15 +1,15 @@
 import * as React from "react";
-import * as ReactDOM from "react-dom";
 import * as trcSheet from 'trc-sheet/sheet'
-import { IMajorState } from "./SheetContainer";
 
-declare var _trcGlobal: IMajorState;
+import TRCContext from "./context/TRCContext";
 
-// List column names. 
+// List column names.
 export class ListColumns extends React.Component<{
     Include?: (ci: trcSheet.IColumnInfo) => boolean;
 }, {
 }> {
+    static contextType = TRCContext;
+
     constructor(props: any) {
         if (!props.Include) {
             props.Include = (ci: any) => true;
@@ -27,12 +27,12 @@ export class ListColumns extends React.Component<{
     }
 
     public render()  {
-        var cis = _trcGlobal._info.Columns;
+        var cis = this.context._info.Columns;
         return <div>
             <ul>
-                {cis.map( (ci, idx) => this.props.Include(ci) && <li key={idx}>
+                {cis.map( (ci: any, idx: any) => this.props.Include(ci) && <li key={idx}>
                     {this.getStr(ci)}
-                </li>)}                
+                </li>)}
             </ul>
         </div>
     }

--- a/src/PluginLink.tsx
+++ b/src/PluginLink.tsx
@@ -1,20 +1,22 @@
 import * as React from "react";
 
-import { IMajorState } from "./SheetContainer";
+import TRCContext from "./context/TRCContext";
 
-declare var _trcGlobal: IMajorState;
+import { IMajorState } from "./SheetContainer";
 
 // Helper for creating hyperlink to another plugin (same sheet)
 export class PluginLink extends React.Component<{
-    id: string, // plugin id to display 
+    id: string, // plugin id to display
     sheetId?: string // pull from global if missing
     url?: string // query or hash
 }, {}>
 {
+    static contextType = TRCContext;
+
     private _url: string;
 
-    public constructor(props: any) {
-        super(props);
+    public constructor(props: any, context: IMajorState) {
+        super(props, context);
 
 
         // https://canvas.voter-science.com/plugin/47c41c7d5e2946bfb30d254f142d7000/audit
@@ -23,7 +25,7 @@ export class PluginLink extends React.Component<{
 
         var sheetId = this.props.sheetId;
         if (!sheetId) {
-            sheetId = _trcGlobal.SheetId;
+            sheetId = this.context.SheetId;
         }
 
         this._url = "https://canvas.voter-science.com/plugin/" +

--- a/src/Questions.tsx
+++ b/src/Questions.tsx
@@ -9,8 +9,6 @@ import { HorizontalList } from "./common/HorizontalList";
 import { SelectInput } from "./common/SelectInput";
 import { TextInput } from "./common/TextInput";
 
-declare var _trcGlobal: IMajorState;
-
 // Render multiple questions with a "submit" button.
 // Still assumed to be for a single RecId.
 // record is a map of QuestionName=Value

--- a/src/context/TRCContext.ts
+++ b/src/context/TRCContext.ts
@@ -1,0 +1,5 @@
+import * as React from 'react';
+
+const TRCContext = React.createContext(null);
+
+export default TRCContext;


### PR DESCRIPTION
This change will allow us to remove any reference of `_trcGlobal` from plugins that depend on `trc-react`.