### PR TITLE
Fix Panel component props interface

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "trc-react",
-  "version": "2.5.0",
+  "version": "2.5.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "trc-react",
-  "version": "2.5.0",
+  "version": "2.5.1",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/src/common/Panel.tsx
+++ b/src/common/Panel.tsx
@@ -4,7 +4,7 @@ import styled from '@emotion/styled';
 // Panel is a container for grouping related content.
 
 interface IProps {
-  children: JSX.Element[];
+  children: React.ReactNode | React.ReactNode[];
 }
 
 const Container = styled.div`


### PR DESCRIPTION
This fix allows the <Panel> component to receive a single children. Before, the TypeScript compiler was complaining when a single children was passed to the component, requiring at least 2 of them.