### PR TITLE
Show Panel component overflow

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "trc-react",
-  "version": "2.5.1",
+  "version": "2.5.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "trc-react",
-  "version": "2.5.1",
+  "version": "2.5.2",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/src/common/Panel.tsx
+++ b/src/common/Panel.tsx
@@ -14,7 +14,6 @@ const Container = styled.div`
   padding: 2rem;
   margin: 2rem auto;
   max-width: 900px;
-  overflow: hidden;
   > *:first-child {
     margin-top: 0;
   }


### PR DESCRIPTION
This PR deletes the `overflow: hidden` css rule from the `<Panel>` component, avoiding things like custom dropdown to be visually cut.