### PR TITLE
Add initial tab prop to TabsPanel

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "trc-react",
-  "version": "2.5.3",
+  "version": "2.5.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "trc-react",
-  "version": "2.5.3",
+  "version": "2.5.4",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/src/common/TabsPanel.tsx
+++ b/src/common/TabsPanel.tsx
@@ -5,6 +5,7 @@ import styled from "@emotion/styled";
 
 interface IProps {
   children: React.ReactNode[];
+  initialTab?: string;
   tabNames: string[];
 }
 
@@ -51,8 +52,8 @@ const TabContent = styled.div`
   }
 `;
 
-export const TabsPanel = ({ children, tabNames }: IProps) => {
-  const [activeTab, setActiveTab] = React.useState(tabNames[0]);
+export const TabsPanel = ({ children, initialTab, tabNames }: IProps) => {
+  const [activeTab, setActiveTab] = React.useState(initialTab || tabNames[0]);
 
   return (
     <Container>


### PR DESCRIPTION
The new `initialTab` prop permits us to set which tab should be open by default when the component renders. Before, the first tab was always the one opened by default.