### PR TITLE
Add noBlank prop to SelectInput

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "trc-react",
-  "version": "2.7.1",
+  "version": "2.7.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "trc-react",
-  "version": "2.7.1",
+  "version": "2.7.2",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/src/common/SelectInput.tsx
+++ b/src/common/SelectInput.tsx
@@ -7,6 +7,7 @@ import styled from "@emotion/styled";
 interface IProps extends React.SelectHTMLAttributes<HTMLSelectElement> {
   error?: string;
   label?: string;
+  noBlank?: boolean;
   options: any[];
   small?: boolean;
   values?: any[];
@@ -65,6 +66,7 @@ const Select = styled.select<ISizingProps>`
 export const SelectInput = ({
   error,
   label,
+  noBlank,
   options,
   small,
   values,
@@ -73,7 +75,7 @@ export const SelectInput = ({
   <Wrapper>
     {label && <Label small={small}>{label}:</Label>}
     <Select small={small} {...rest}>
-      <option />
+      {!noBlank && <option />}
       {options.map((option, i) => (
         <option key={i} value={values ? values[i] : option}>
           {option}


### PR DESCRIPTION
The `noBlank` props is used to configure if a blank option should be present or not in the select dropdown.